### PR TITLE
Add Uno login mask with REST API calls

### DIFF
--- a/Frontend/App.xaml.cs
+++ b/Frontend/App.xaml.cs
@@ -2,6 +2,7 @@ using Frontend.Models;
 using Frontend.Presentation;
 using Frontend.Services.Caching;
 using Frontend.Services.Endpoints;
+using LoginModel = Frontend.Presentation.LoginModel;
 using Uno.Resizetizer;
 using MainModel = Frontend.Presentation.MainModel;
 using SecondModel = Frontend.Presentation.SecondModel;
@@ -87,12 +88,19 @@ public partial class App : Application
                                     Url = context.Configuration["ApiClient:Url"]!,
                                 }
                             );
+                            services.AddHttpClient<Services.Auth.AuthService>(client =>
+                            {
+                                var url = context.Configuration["ApiClient:Url"];
+                                if (!string.IsNullOrEmpty(url))
+                                {
+                                    client.BaseAddress = new Uri(url);
+                                }
+                            });
                         }
                     )
                     .ConfigureServices(
                         (context, services) => {
-                            // TODO: Register your services
-                            //services.AddSingleton<IMyService, MyService>();
+                            services.AddSingleton<Services.Auth.AuthService>();
                         }
                     )
                     .UseNavigation(ReactiveViewModelMappings.ViewModelMappings, RegisterRoutes)
@@ -111,6 +119,7 @@ public partial class App : Application
     {
         views.Register(
             new ViewMap(ViewModel: typeof(ShellModel)),
+            new ViewMap<LoginPage, LoginModel>(),
             new ViewMap<MainPage, MainModel>(),
             new DataViewMap<SecondPage, SecondModel, Entity>()
         );
@@ -121,7 +130,8 @@ public partial class App : Application
                 View: views.FindByViewModel<ShellModel>(),
                 Nested:
                 [
-                    new("Main", View: views.FindByViewModel<MainModel>(), IsDefault: true),
+                    new("Login", View: views.FindByViewModel<LoginModel>(), IsDefault: true),
+                    new("Main", View: views.FindByViewModel<MainModel>()),
                     new("Second", View: views.FindByViewModel<SecondModel>()),
                 ]
             )

--- a/Frontend/Models/LoginCommand.cs
+++ b/Frontend/Models/LoginCommand.cs
@@ -1,0 +1,3 @@
+namespace Frontend.Models;
+
+public record LoginCommand(string Code, string? Email, string? PhoneNumber);

--- a/Frontend/Models/RegisterUserCommand.cs
+++ b/Frontend/Models/RegisterUserCommand.cs
@@ -1,0 +1,3 @@
+namespace Frontend.Models;
+
+public record RegisterUserCommand(string DisplayName, string? Email, string? PhoneNumber);

--- a/Frontend/Models/TokenDto.cs
+++ b/Frontend/Models/TokenDto.cs
@@ -1,0 +1,3 @@
+namespace Frontend.Models;
+
+public record TokenDto(string Token);

--- a/Frontend/Presentation/LoginModel.cs
+++ b/Frontend/Presentation/LoginModel.cs
@@ -1,0 +1,49 @@
+namespace Frontend.Presentation;
+
+public partial record LoginModel
+{
+    private readonly INavigator _navigator;
+    private readonly Frontend.Services.Auth.AuthService _auth;
+
+    public LoginModel(INavigator navigator, Frontend.Services.Auth.AuthService auth)
+    {
+        _navigator = navigator;
+        _auth = auth;
+    }
+
+    public IState<string> DisplayName => State<string>.Value(this, () => string.Empty);
+    public IState<string?> Email => State<string?>.Value(this, () => null);
+    public IState<string?> PhoneNumber => State<string?>.Value(this, () => null);
+    public IState<string?> Code => State<string?>.Value(this, () => null);
+
+    public async Task Register()
+    {
+        var name = await DisplayName;
+        var email = await Email;
+        var phone = await PhoneNumber;
+
+        var token = await _auth.RegisterAsync(name, email, phone);
+        if (token is not null)
+        {
+            await _navigator.NavigateViewModelAsync<MainModel>(this);
+        }
+    }
+
+    public async Task Login()
+    {
+        var code = await Code;
+        var email = await Email;
+        var phone = await PhoneNumber;
+
+        if (code is null)
+        {
+            return;
+        }
+
+        var token = await _auth.LoginAsync(code, email, phone);
+        if (token is not null)
+        {
+            await _navigator.NavigateViewModelAsync<MainModel>(this);
+        }
+    }
+}

--- a/Frontend/Presentation/LoginPage.xaml
+++ b/Frontend/Presentation/LoginPage.xaml
@@ -1,0 +1,28 @@
+<Page x:Class="Frontend.Presentation.LoginPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:Frontend.Presentation"
+      xmlns:uen="using:Uno.Extensions.Navigation.UI"
+      xmlns:utu="using:Uno.Toolkit.UI"
+      xmlns:um="using:Uno.Material"
+      Background="{ThemeResource BackgroundBrush}">
+  <ScrollViewer IsTabStop="True">
+    <StackPanel HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                Spacing="12"
+                Margin="20">
+      <TextBox PlaceholderText="Display Name"
+               Text="{Binding DisplayName, Mode=TwoWay}" />
+      <TextBox PlaceholderText="Email"
+               Text="{Binding Email, Mode=TwoWay}" />
+      <TextBox PlaceholderText="Phone"
+               Text="{Binding PhoneNumber, Mode=TwoWay}" />
+      <TextBox PlaceholderText="Code"
+               Text="{Binding Code, Mode=TwoWay}" />
+      <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
+        <Button Content="Register" Command="{Binding Register}" />
+        <Button Content="Login" Command="{Binding Login}" />
+      </StackPanel>
+    </StackPanel>
+  </ScrollViewer>
+</Page>

--- a/Frontend/Presentation/LoginPage.xaml.cs
+++ b/Frontend/Presentation/LoginPage.xaml.cs
@@ -1,0 +1,9 @@
+namespace Frontend.Presentation;
+
+public sealed partial class LoginPage : Page
+{
+    public LoginPage()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/Frontend/Services/Auth/AuthService.cs
+++ b/Frontend/Services/Auth/AuthService.cs
@@ -1,0 +1,47 @@
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Frontend.Models;
+
+namespace Frontend.Services.Auth;
+
+public class AuthService
+{
+    private readonly HttpClient _client;
+    private readonly ISerializer _serializer;
+
+    public AuthService(HttpClient client, ISerializer serializer)
+    {
+        _client = client;
+        _serializer = serializer;
+    }
+
+    public async Task<string?> RegisterAsync(string displayName, string? email, string? phone, CancellationToken ct = default)
+    {
+        var body = new RegisterUserCommand(displayName, email, phone);
+        var content = new StringContent(_serializer.ToString(body), Encoding.UTF8, "application/json");
+        using var response = await _client.PostAsync("/api/users/register", content, ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+        var json = await response.Content.ReadAsStringAsync(ct);
+        var token = _serializer.FromString<TokenDto>(json);
+        return token.Token;
+    }
+
+    public async Task<string?> LoginAsync(string code, string? email, string? phone, CancellationToken ct = default)
+    {
+        var body = new LoginCommand(code, email, phone);
+        var content = new StringContent(_serializer.ToString(body), Encoding.UTF8, "application/json");
+        using var response = await _client.PutAsync("/api/users/login", content, ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+        var json = await response.Content.ReadAsStringAsync(ct);
+        var token = _serializer.FromString<TokenDto>(json);
+        return token.Token;
+    }
+}


### PR DESCRIPTION
## Summary
- add models for login and registration
- implement `AuthService` for REST calls
- create login page and model for Uno UI
- register login route and service

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868046ad5e0832f873352b7f923b658