### PR TITLE
Fix skipped tests

### DIFF
--- a/Application/Features/Habits/Commands/ExecuteHabit.cs
+++ b/Application/Features/Habits/Commands/ExecuteHabit.cs
@@ -71,7 +71,8 @@ public static class ExecuteHabit
                     h =>
                         h.HabitHistoryId == history.Id
                         && h.UserId == history.UserId
-                        && h.Date == history.Date,
+                        && h.HabitId == habitId
+                        && h.Date.Date == history.Date.Date,
                     ct
                 );
 

--- a/Infrastructure/Specifications/Users/SearchUsersSpecification.cs
+++ b/Infrastructure/Specifications/Users/SearchUsersSpecification.cs
@@ -1,6 +1,7 @@
 using Application.Features.Users.Specifications;
 using Application.Repositories;
 using Domain.Entities;
+using LinqKit;
 using Microsoft.EntityFrameworkCore;
 
 namespace Infrastructure.Specifications.Users;
@@ -9,18 +10,25 @@ public class SearchUsersSpecification(IRepository<User> repository)
     : BaseSpecification<User>(repository),
         ISearchUsersSpecification
 {
+    private ExpressionStarter<User> _predicate = PredicateBuilder.New<User>(false);
+
     public ISearchUsersSpecification ByName(string name)
     {
-        return (ISearchUsersSpecification)ApplyCriteria(x =>
-            x.DisplayNameSearchVector.Matches(EF.Functions.PlainToTsQuery(name))
+        _predicate = _predicate.Or(
+            x => x.DisplayNameSearchVector.Matches(EF.Functions.PlainToTsQuery(name))
         );
+        ApplyCriteria(_predicate);
+        return this;
     }
 
     public ISearchUsersSpecification ByContact(string term)
     {
-        return (ISearchUsersSpecification)ApplyCriteria(x =>
-            EF.Functions.ILike(x.Email ?? "", $"%{term}%") ||
-            EF.Functions.ILike(x.PhoneNumber ?? "", $"%{term}%")
+        _predicate = _predicate.Or(
+            x =>
+                EF.Functions.ILike(x.Email ?? "", $"%{term}%") ||
+                EF.Functions.ILike(x.PhoneNumber ?? "", $"%{term}%")
         );
+        ApplyCriteria(_predicate);
+        return this;
     }
 }

--- a/Tests/Unit.Tests/Features/Chats/CommandHandlerTests/CreateChatRoomCommandHandlerTests.cs
+++ b/Tests/Unit.Tests/Features/Chats/CommandHandlerTests/CreateChatRoomCommandHandlerTests.cs
@@ -31,7 +31,7 @@ public class CreateChatRoomCommandHandlerTests(
         });
     }
 
-    [Fact(Skip = "Require change")]
+    [Fact]
     public async Task CreateChatRoom_PrivateTwoUsers_ShouldMarkDirect()
     {
         var user1 = new User { DisplayName = "A" };

--- a/Tests/Unit.Tests/Features/Habits/CommandHandlerTests/ExecuteHabitCommandHandlerTests.cs
+++ b/Tests/Unit.Tests/Features/Habits/CommandHandlerTests/ExecuteHabitCommandHandlerTests.cs
@@ -196,7 +196,7 @@ public class ExecuteHabitCommandHandlerTests(
         });
     }
 
-    [Fact(Skip = "Require Change")]
+    [Fact]
     public async Task ExecuteHabit_WithExistingTriggeredHistory_ShouldNotDuplicate()
     {
         var user = new User { DisplayName = "NoDup" };

--- a/Tests/Unit.Tests/Features/Users/QueryHandlerTests/SearchUserByNameQueryHandlerTests.cs
+++ b/Tests/Unit.Tests/Features/Users/QueryHandlerTests/SearchUserByNameQueryHandlerTests.cs
@@ -12,7 +12,7 @@ public class SearchUserByNameQueryHandlerTests(
     ITestOutputHelper outputHelper
 ) : FeatureTestBase(fixture, outputHelper)
 {
-    [Fact(Skip = "Require Change")]
+    [Fact]
     public async Task SearchUserByName_WithMatchingName_ShouldReturnUsers()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- implement OR query in `SearchUsersSpecification`
- refine duplicate check in `ExecuteHabit` command
- enable previously skipped tests

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: tests require extra setup)*

------
https://chatgpt.com/codex/tasks/task_e_6885fc774524832facdad8a4c0e560ec